### PR TITLE
Use global.auth.OidcIssuerUrl instead of issuerUrl

### DIFF
--- a/deployments/dex-server/templates/configmap.yaml
+++ b/deployments/dex-server/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "dex-server.labels" . | nindent 4 }}
 data:
   config.yaml: |
-    issuer: {{ .Values.issuerUrl }}
+    issuer: {{ .Values.global.auth.oidcIssuerUrl }}
     storage:
       type: sqlite3
       config:

--- a/deployments/dex-server/values.yaml
+++ b/deployments/dex-server/values.yaml
@@ -1,8 +1,10 @@
 global:
   ingress:
-    ingressClassName: kong
+    ingressClassName:
 
-issuerUrl: http://kong-kong-proxy.kong/dex
+  auth:
+    oidcIssuerUrl:
+
 httpPort: 5556
 
 client:

--- a/deployments/rbac-server/values.yaml
+++ b/deployments/rbac-server/values.yaml
@@ -2,7 +2,7 @@ global:
   auth:
     oidcIssuerUrl:
 
-internalGrpcPort: 8081 
+internalGrpcPort: 8081
 
 debug:
   userOrgMap:
@@ -24,4 +24,4 @@ image:
   repository: public.ecr.aws/v8n3t7y5/llm-operator/rbac-server
   pullPolicy: IfNotPresent
 
-version: latest
+version:


### PR DESCRIPTION
Also remove some of the default value definitions. These will be set in llm-operator/hack/llm-operator-values.yaml as we don't necessarily need to make kong as a default ingress controller option for users.