### PR TITLE
Add /v1 to the ingress path

### DIFF
--- a/deployments/dex-server/templates/ingress.yaml
+++ b/deployments/dex-server/templates/ingress.yaml
@@ -9,7 +9,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /dex
+      - path: /v1/dex
         pathType: Prefix
         backend:
           service:

--- a/hack/cmd/main.go
+++ b/hack/cmd/main.go
@@ -20,7 +20,7 @@ const (
 	defaultClientID     = "llm-operator"
 	defaultClientSecret = "ZXhhbXBsZS1hcHAtc2VjcmV0"
 	defaultRedirectURI  = "http://127.0.0.1:5555/callback"
-	defaultIssuerURL    = "http://kong-kong-proxy.kong/dex"
+	defaultIssuerURL    = "http://kong-kong-proxy.kong/v1/dex"
 	defaultNodeIP       = "127.0.0.1"
 )
 


### PR DESCRIPTION
This might not be very useful, but wanted to be consistent with other endpoints.