### PR TITLE
Fix the APIKey cache

### DIFF
--- a/server/internal/apikey/cache_test.go
+++ b/server/internal/apikey/cache_test.go
@@ -15,10 +15,12 @@ func TestCache(t *testing.T) {
 		resp: &uv1.ListAPIKeysResponse{
 			Data: []*uv1.APIKey{
 				{
-					Id: "id0",
+					Id:     "id0",
+					Secret: "s0",
 				},
 				{
-					Id: "id1",
+					Id:     "id1",
+					Secret: "s1",
 				},
 			},
 		},
@@ -31,17 +33,17 @@ func TestCache(t *testing.T) {
 	assert.NoError(t, err)
 
 	want := map[string]*K{
-		"id0": {
+		"s0": {
 			Role: "role",
 		},
-		"id1": {
+		"s1": {
 			Role: "role",
 		},
-		"id2": nil,
+		"s2": nil,
 	}
 
 	for k, v := range want {
-		got, ok := c.GetAPIKey(k)
+		got, ok := c.GetAPIKeyBySecret(k)
 		if v == nil {
 			assert.False(t, ok)
 			continue

--- a/server/internal/server/authorization.go
+++ b/server/internal/server/authorization.go
@@ -19,7 +19,7 @@ func (s *Server) Authorize(ctx context.Context, req *v1.AuthorizeRequest) (*v1.A
 	}
 
 	// Check if the token is the API key.
-	key, ok := s.apiKeyCache.GetAPIKey(req.Token)
+	key, ok := s.apiKeyCache.GetAPIKeyBySecret(req.Token)
 	if ok {
 		return &v1.AuthorizeResponse{
 			Authorized: s.authorizedAPIKey(key, req.Scope),

--- a/server/internal/server/authorization_test.go
+++ b/server/internal/server/authorization_test.go
@@ -37,11 +37,11 @@ func TestAuthorize(t *testing.T) {
 		{
 			name: "authorized with API key",
 			req: &v1.AuthorizeRequest{
-				Token: "keyID",
+				Token: "keySecret",
 				Scope: "api.object.read",
 			},
 			cache: map[string]*apikey.K{
-				"keyID": {
+				"keySecret": {
 					Role: "all",
 				},
 			},
@@ -50,11 +50,11 @@ func TestAuthorize(t *testing.T) {
 		{
 			name: "unauthorized with invalid role in API key",
 			req: &v1.AuthorizeRequest{
-				Token: "keyID",
+				Token: "keySecret",
 				Scope: "api.object.read",
 			},
 			cache: map[string]*apikey.K{
-				"keyID": {
+				"keySecret": {
 					Role: "different-role",
 				},
 			},
@@ -63,7 +63,7 @@ func TestAuthorize(t *testing.T) {
 		{
 			name: "authorized with dex",
 			req: &v1.AuthorizeRequest{
-				Token: "keyID",
+				Token: "jwt",
 				Scope: "api.object.read",
 			},
 			cache: map[string]*apikey.K{},
@@ -78,7 +78,7 @@ func TestAuthorize(t *testing.T) {
 		{
 			name: "unauthorized with inactive token",
 			req: &v1.AuthorizeRequest{
-				Token: "keyID",
+				Token: "jwt",
 				Scope: "api.object.read",
 			},
 			cache: map[string]*apikey.K{},
@@ -93,7 +93,7 @@ func TestAuthorize(t *testing.T) {
 		{
 			name: "unauthorized with invalid user",
 			req: &v1.AuthorizeRequest{
-				Token: "keyID",
+				Token: "jwt",
 				Scope: "api.object.read",
 			},
 			cache: map[string]*apikey.K{},
@@ -109,7 +109,7 @@ func TestAuthorize(t *testing.T) {
 		{
 			name: "unauthorized with scope",
 			req: &v1.AuthorizeRequest{
-				Token: "keyID",
+				Token: "jwt",
 				Scope: "api.different-object.read",
 			},
 			cache: map[string]*apikey.K{},
@@ -156,7 +156,7 @@ type fakeAPIKeyCache struct {
 	cache map[string]*apikey.K
 }
 
-func (c *fakeAPIKeyCache) GetAPIKey(keyID string) (*apikey.K, bool) {
-	k, ok := c.cache[keyID]
+func (c *fakeAPIKeyCache) GetAPIKeyBySecret(secret string) (*apikey.K, bool) {
+	k, ok := c.cache[secret]
 	return k, ok
 }

--- a/server/internal/server/server.go
+++ b/server/internal/server/server.go
@@ -13,7 +13,7 @@ import (
 )
 
 type apikeyCache interface {
-	GetAPIKey(keyID string) (*apikey.K, bool)
+	GetAPIKeyBySecret(secret string) (*apikey.K, bool)
 }
 
 type tokenIntrospector interface {


### PR DESCRIPTION
We need to check the token against a secret, not key ID.