### PR TITLE
Change the default org name to 'default'

### DIFF
--- a/deployments/rbac-server/values.yaml
+++ b/deployments/rbac-server/values.yaml
@@ -10,9 +10,9 @@ apiKeyCache:
 
 debug:
   userOrgMap:
-    admin@example.com: example-org
+    admin@example.com: default
   orgRoleMap:
-    example-org: all
+    default: all
   roleScopesMap:
     all:
     - api.model.read


### PR DESCRIPTION
This will make fine-tuning jobs run in the default namespace by default.