### PR TITLE
Avoid hard dependency from user-manager-server to rbac-server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 # Go workspace file
 go.work
+
+# Directory where binaries are stored.
+bin/

--- a/server/internal/cache/cache.go
+++ b/server/internal/cache/cache.go
@@ -92,7 +92,9 @@ func (c *Store) Sync(ctx context.Context, interval time.Duration) error {
 			return ctx.Err()
 		case <-ticker.C:
 			if err := c.updateCache(ctx); err != nil {
-				return err
+				// Gracefully ignore the error.
+				// TODO(kenji): Make the pod unready.
+				log.Printf("Failed to update the cache: %s. Ignoring.", err)
 			}
 		}
 	}
@@ -101,10 +103,7 @@ func (c *Store) Sync(ctx context.Context, interval time.Duration) error {
 func (c *Store) updateCache(ctx context.Context) error {
 	resp, err := c.userInfoLister.ListAPIKeys(ctx, &uv1.ListAPIKeysRequest{})
 	if err != nil {
-		// Gracefully ignore the error.
-		// TODO(kenji): Make the pod unready.
-		log.Printf("Failed to list API keys: %s. Ignoring.", err)
-		return nil
+		return err
 	}
 
 	m := map[string]*K{}

--- a/server/internal/cache/cache.go
+++ b/server/internal/cache/cache.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"log"
 	"sync"
 	"time"
 
@@ -100,7 +101,10 @@ func (c *Store) Sync(ctx context.Context, interval time.Duration) error {
 func (c *Store) updateCache(ctx context.Context) error {
 	resp, err := c.userInfoLister.ListAPIKeys(ctx, &uv1.ListAPIKeysRequest{})
 	if err != nil {
-		return err
+		// Gracefully ignore the error.
+		// TODO(kenji): Make the pod unready.
+		log.Printf("Failed to list API keys: %s. Ignoring.", err)
+		return nil
 	}
 
 	m := map[string]*K{}


### PR DESCRIPTION
rbac-server needs to be highly available, so it's better to keep it up and running even when cache update is not working.