### PR TITLE
Add CarryMetadata

### DIFF
--- a/pkg/auth/interceptor.go
+++ b/pkg/auth/interceptor.go
@@ -18,6 +18,7 @@ const (
 	capRead  = "read"
 	capWrite = "write"
 
+	authHeader = "Authorization"
 	// orgHeader is the header key for organization ID.
 	// The header defined in https://platform.openai.com/docs/api-reference/authentication
 	// "OpenAI-Organization", but what we receive is "Openai-Organization".
@@ -134,7 +135,7 @@ func extractTokenFromContext(ctx context.Context) (string, error) {
 	if !ok {
 		return "", status.Errorf(codes.InvalidArgument, "missing metadata")
 	}
-	auth := md["authorization"]
+	auth := md[strings.ToLower(authHeader)]
 	if len(auth) < 1 {
 		return "", status.Errorf(codes.Unauthenticated, "missing authorization")
 	}
@@ -166,7 +167,7 @@ func extractProjectIDFromContext(ctx context.Context) string {
 }
 
 func extractTokenFromHeader(header http.Header) (string, bool) {
-	auth := header["Authorization"]
+	auth := header[authHeader]
 	if len(auth) < 1 {
 		return "", false
 	}

--- a/pkg/auth/metadata.go
+++ b/pkg/auth/metadata.go
@@ -1,0 +1,33 @@
+package auth
+
+import (
+	"context"
+	"strings"
+
+	"google.golang.org/grpc/metadata"
+)
+
+// CarryMetadata extracts relevant metadata from the incoming context
+// and append that to the outgoing context.
+func CarryMetadata(ctx context.Context) context.Context {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ctx
+	}
+
+	headers := []string{
+		authHeader,
+		orgHeader,
+		projectHeader,
+	}
+	for _, header := range headers {
+		key := strings.ToLower(header)
+		v, ok := md[key]
+		if !ok {
+			continue
+		}
+
+		ctx = metadata.AppendToOutgoingContext(ctx, header, v[0])
+	}
+	return ctx
+}

--- a/pkg/auth/metadata_test.go
+++ b/pkg/auth/metadata_test.go
@@ -1,0 +1,27 @@
+package auth
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestCarryMetadata(t *testing.T) {
+	md := map[string][]string{
+		strings.ToLower(authHeader):    {"a0"},
+		strings.ToLower(orgHeader):     {"o0"},
+		strings.ToLower(projectHeader): {"p0"},
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	ctx = CarryMetadata(ctx)
+
+	got, ok := metadata.FromOutgoingContext(ctx)
+	assert.True(t, ok)
+	assert.ElementsMatch(t, []string{"a0"}, got.Get(authHeader))
+	assert.ElementsMatch(t, []string{"o0"}, got.Get(orgHeader))
+	assert.ElementsMatch(t, []string{"p0"}, got.Get(projectHeader))
+}


### PR DESCRIPTION
CarryMetadata extracts relevant metadata from the incoming context and append that to the outgoing context.