### PR TITLE
Add "api.organizations.read" to projectMember

### DIFF
--- a/deployments/rbac-server/values.yaml
+++ b/deployments/rbac-server/values.yaml
@@ -35,8 +35,7 @@ roleScopesMap:
   - api.files.write
   - api.users.api_keys.read
   - api.users.api_keys.write
-  # TODO(kenji): Revisit. Other resources are scoped by a single project (e.g., view all models in a given project), but
-  # "projects" are not scoped (e.g., view all projects where I'm a member).
+  - api.organizations.read
   - api.organizations.projects.read
   - api.organizations.projects.users.write
   - api.organizations.projects.users.read
@@ -49,8 +48,7 @@ roleScopesMap:
   - api.files.write
   - api.users.api_keys.read
   - api.users.api_keys.write
-  # TODO(kenji): Revisit. Other resources are scoped by a single project (e.g., view all models in a given project), but
-  # "projects" are not scoped (e.g., view all projects where I'm a member).
+  - api.organizations.read
   - api.organizations.projects.read
   - api.organizations.projects.users.read
 


### PR DESCRIPTION
We would like to allow a user to see orgs where she/he belongs.

Also removed the TODO comment. We will do additional check in user manager.