### PR TITLE
Handle org resources specially

### DIFF
--- a/deployments/rbac-server/values.yaml
+++ b/deployments/rbac-server/values.yaml
@@ -18,14 +18,6 @@ roleScopesMap:
   - api.files.write
   - api.users.api_keys.read
   - api.users.api_keys.write
-  - api.organizations.read
-  - api.organizations.write
-  - api.organizations.users.write
-  - api.organizations.users.read
-  - api.organizations.projects.read
-  - api.organizations.projects.write
-  - api.organizations.projects.users.write
-  - api.organizations.projects.users.read
   projectOwner:
   - api.model.read
   - api.model.write
@@ -35,10 +27,6 @@ roleScopesMap:
   - api.files.write
   - api.users.api_keys.read
   - api.users.api_keys.write
-  - api.organizations.read
-  - api.organizations.projects.read
-  - api.organizations.projects.users.write
-  - api.organizations.projects.users.read
   projectMember:
   - api.model.read
   - api.model.write
@@ -48,9 +36,7 @@ roleScopesMap:
   - api.files.write
   - api.users.api_keys.read
   - api.users.api_keys.write
-  - api.organizations.read
-  - api.organizations.projects.read
-  - api.organizations.projects.users.read
+
 
 debug:
   apiKeyRole: projectMember


### PR DESCRIPTION
We cannot handle the access control of orgs and projects with the current mechanism, which only works when a resource is project-scoped.

For example, when a user attempts to list all projects in a given org, we need to let a caller know which project is visible. On the other hand, the current authorization API checks if a user is allowed to read/write to a resource in a specific project and org.

We could extend the API, but it is simpler to implement the auth logic in the caller (= user-manager).