### PR TITLE
Add CarryMetadataFromHTTPHeader

### DIFF
--- a/pkg/auth/metadata.go
+++ b/pkg/auth/metadata.go
@@ -2,13 +2,14 @@ package auth
 
 import (
 	"context"
+	"net/http"
 	"strings"
 
 	"google.golang.org/grpc/metadata"
 )
 
 // CarryMetadata extracts relevant metadata from the incoming context
-// and append that to the outgoing context.
+// and appends that to the outgoing context.
 func CarryMetadata(ctx context.Context) context.Context {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
@@ -28,6 +29,24 @@ func CarryMetadata(ctx context.Context) context.Context {
 		}
 
 		ctx = metadata.AppendToOutgoingContext(ctx, header, v[0])
+	}
+	return ctx
+}
+
+// CarryMetadataFromHTTPHeader extracts relevant metadata from HTTP headers
+// and appends that to the outgoing context.
+func CarryMetadataFromHTTPHeader(ctx context.Context, header http.Header) context.Context {
+	keys := []string{
+		authHeader,
+		orgHeader,
+		projectHeader,
+	}
+	for _, k := range keys {
+		v, ok := header[k]
+		if !ok {
+			continue
+		}
+		ctx = metadata.AppendToOutgoingContext(ctx, k, v[0])
 	}
 	return ctx
 }

--- a/pkg/auth/metadata_test.go
+++ b/pkg/auth/metadata_test.go
@@ -25,3 +25,18 @@ func TestCarryMetadata(t *testing.T) {
 	assert.ElementsMatch(t, []string{"o0"}, got.Get(orgHeader))
 	assert.ElementsMatch(t, []string{"p0"}, got.Get(projectHeader))
 }
+
+func TestCarryMetadataFromHTTPHeader(t *testing.T) {
+	header := map[string][]string{
+		authHeader:    {"a0"},
+		orgHeader:     {"o0"},
+		projectHeader: {"p0"},
+	}
+
+	ctx := CarryMetadataFromHTTPHeader(context.Background(), header)
+	got, ok := metadata.FromOutgoingContext(ctx)
+	assert.True(t, ok)
+	assert.ElementsMatch(t, []string{"a0"}, got.Get(authHeader))
+	assert.ElementsMatch(t, []string{"o0"}, got.Get(orgHeader))
+	assert.ElementsMatch(t, []string{"p0"}, got.Get(projectHeader))
+}


### PR DESCRIPTION
This is used to make an RPC call from an HTTP handler (e.g., call Model Manager from the completion HTTP handler).