### PR TITLE
Remove api.users.api_keys from access resources

### DIFF
--- a/deployments/rbac-server/values.yaml
+++ b/deployments/rbac-server/values.yaml
@@ -18,8 +18,6 @@ roleScopesMap:
   - api.workspaces.notebooks.write
   - api.files.read
   - api.files.write
-  - api.users.api_keys.read
-  - api.users.api_keys.write
   projectOwner:
   - api.model.read
   - api.model.write
@@ -29,8 +27,6 @@ roleScopesMap:
   - api.workspaces.notebooks.write
   - api.files.read
   - api.files.write
-  - api.users.api_keys.read
-  - api.users.api_keys.write
   projectMember:
   - api.model.read
   - api.model.write
@@ -40,9 +36,6 @@ roleScopesMap:
   - api.workspaces.notebooks.write
   - api.files.read
   - api.files.write
-  - api.users.api_keys.read
-  - api.users.api_keys.write
-
 
 debug:
   apiKeyRole: projectMember


### PR DESCRIPTION
The new resource name is api.organizations.projects.api_keys, and the Authorize function ignores the check for access resources of the "api.organizations" prefix.