### PR TITLE
Use a specific tag for dex docker image

### DIFF
--- a/deployments/dex-server/values.yaml
+++ b/deployments/dex-server/values.yaml
@@ -35,7 +35,7 @@ admin:
 image:
   repository: dexidp/dex
   pullPolicy: IfNotPresent
-  tag: latest
+  tag: v2.39.1-distroless
 
 envsubst:
   image:


### PR DESCRIPTION
We used to use "latest", and I started getting the following error this morning.

```
➜ kubectl logs -n llm-operator dex-server-7dc6757676-txbtv Defaulted container "dex" out of: dex, envsubst (init) panic: nil Handler

goroutine 1 [running]:
log/slog.New(...)
	/usr/local/go/src/log/slog/logger.go:154
main.newLogger(0x0, {0x0, 0x0})
	/usr/local/src/dex/cmd/dex/serve.go:534 +0x1ac
main.runServe({{0xfffff9435c6c, 0x1e}, {0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}})
	/usr/local/src/dex/cmd/dex/serve.go:95 +0x22c
main.commandServe.func1(0x400050c300?, {0x400051b360?, 0x4?, 0x555067?})
	/usr/local/src/dex/cmd/dex/serve.go:67 +0x88
github.com/spf13/cobra.(*Command).execute(0x40002ae608, {0x400051b330, 0x1, 0x1})
	/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0x840
github.com/spf13/cobra.(*Command).ExecuteC(0x40002ae308)
	/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
	/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
main.main()
	/usr/local/src/dex/cmd/dex/main.go:24 +0x20
```

Haven't looked into details, but it is better to avoid the "latest" tag.