### PR TITLE
Revert "Enable the docker check flag and refactor Dockerfile (#84)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ build-server:
 
 .PHONY: build-docker-server
 build-docker-server:
-	docker build --check --build-arg TARGETARCH=amd64 -t llm-operator/rbac-server:latest -f build/server/Dockerfile .
+	docker build --build-arg TARGETARCH=amd64 -t llm-operator/rbac-server:latest -f build/server/Dockerfile .
 
 .PHONY: build-docker-envsubst
 build-docker-envsubst:
-	docker build --check --build-arg TARGETARCH=amd64 -t llm-operator/envsubst:latest -f build/envsubst/Dockerfile .
+	docker build --build-arg TARGETARCH=amd64 -t llm-operator/envsubst:latest -f build/envsubst/Dockerfile .

--- a/build/server/Dockerfile
+++ b/build/server/Dockerfile
@@ -1,11 +1,12 @@
-FROM --platform=$BUILDPLATFORM golang:1.22 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.22 as builder
 ARG TARGETARCH
 
 WORKDIR /workspace
 COPY . .
 
 ENV GOCACHE=/root/gocache
-RUN --mount=type=cache,target=${GOCACHE} \
+RUN \
+    --mount=type=cache,target=${GOCACHE} \
     --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
@@ -14,8 +15,10 @@ RUN --mount=type=cache,target=${GOCACHE} \
     CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} GO111MODULE=on make build-server
 
 FROM --platform=$BUILDPLATFORM gcr.io/distroless/static:nonroot
+ARG TARGETARCH
 
 WORKDIR /run
+
 COPY --from=builder /workspace/bin/server .
 
 ENTRYPOINT ["./server"]


### PR DESCRIPTION
This reverts commit 2e6edbf4a4e746a47f679924c79768e7db7a7aed.

Sorry, my bad. The build target should not have been given the ’-check` flag.
This flag just checks the Dockerfile and does not store the build image.