### PR TITLE
Replace issuerURL with dexServerAddr

### DIFF
--- a/deployments/rbac-server/templates/configmap.yaml
+++ b/deployments/rbac-server/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   config.yaml: |
     internalGrpcPort: {{ .Values.internalGrpcPort }}
-    issuerUrl: {{ .Values.global.auth.oidcIssuerUrl }}
+    dexServerAddr: {{ .Values.global.auth.dexServerAddr }}
     cache:
       syncInterval: {{ .Values.cache.syncInterval }}
       userManagerServerInternalAddr: {{ .Values.cache.userManagerServerInternalAddr }}

--- a/deployments/rbac-server/values.yaml
+++ b/deployments/rbac-server/values.yaml
@@ -1,8 +1,8 @@
+internalGrpcPort: 8082
+
 global:
   auth:
-    oidcIssuerUrl:
-
-internalGrpcPort: 8082
+    dexServerAddr:
 
 cache:
   syncInterval: 10s
@@ -33,7 +33,7 @@ roleScopesMap:
   - api.workspaces.notebooks.read
   - api.workspaces.notebooks.write
   - api.batch.jobs.read
-  - api.batch.jobs.write 
+  - api.batch.jobs.write
   - api.files.read
   - api.files.write
   - api.vector-stores.read
@@ -46,7 +46,7 @@ roleScopesMap:
   - api.workspaces.notebooks.read
   - api.workspaces.notebooks.write
   - api.batch.jobs.read
-  - api.batch.jobs.write 
+  - api.batch.jobs.write
   - api.files.read
   - api.files.write
   - api.vector-stores.read
@@ -84,7 +84,7 @@ livenessProbe:
 podSecurityContext:
   fsGroup: 2000
 securityContext:
-  readOnlyRootFilesystem: true  
+  readOnlyRootFilesystem: true
   capabilities:
     drop:
     - ALL

--- a/server/cmd/run.go
+++ b/server/cmd/run.go
@@ -77,7 +77,7 @@ func run(ctx context.Context, c *config.Config) error {
 	// TODO(kenji): Consider revisit this.
 
 	go func() {
-		srv := server.New(c.IssuerURL, cstore, c.RoleScopesMap)
+		srv := server.New(c.DexServerAddr, cstore, c.RoleScopesMap)
 		errCh <- srv.Run(ctx, c.InternalGRPCPort)
 	}()
 

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -12,7 +12,7 @@ import (
 type Config struct {
 	InternalGRPCPort int `yaml:"internalGrpcPort"`
 
-	IssuerURL string `yaml:"issuerUrl"`
+	DexServerAddr string `yaml:"dexServerAddr"`
 
 	CacheConfig CacheConfig `yaml:"cache"`
 
@@ -27,8 +27,8 @@ func (c *Config) Validate() error {
 	if c.InternalGRPCPort <= 0 {
 		return fmt.Errorf("internalGrpcPort must be greater than 0")
 	}
-	if c.IssuerURL == "" {
-		return fmt.Errorf("issuerUrl must be set")
+	if c.DexServerAddr == "" {
+		return fmt.Errorf("dexServerAddr must be set")
 	}
 	if err := c.CacheConfig.validate(); err != nil {
 		return fmt.Errorf("cache: %s", err)

--- a/server/internal/dex/client.go
+++ b/server/internal/dex/client.go
@@ -27,18 +27,18 @@ type IntrospectionExtra struct {
 }
 
 // NewDefaultClient returns a new default client.
-func NewDefaultClient(issuerURL string) Client {
-	return &defaultClient{issuerURL: issuerURL}
+func NewDefaultClient(dexServerAddr string) Client {
+	return &defaultClient{dexServerAddr: dexServerAddr}
 }
 
 type defaultClient struct {
-	issuerURL string
+	dexServerAddr string
 }
 
 // TokenIntrospect introspects the given token.
 func (c *defaultClient) TokenIntrospect(token string) (*Introspection, error) {
 	resp, err := http.PostForm(
-		fmt.Sprintf("%s/token/introspect", c.issuerURL),
+		fmt.Sprintf("http://%s/token/introspect", c.dexServerAddr),
 		url.Values{"token": {token}})
 	if err != nil {
 		return nil, err

--- a/server/internal/server/server.go
+++ b/server/internal/server/server.go
@@ -34,9 +34,9 @@ type tokenIntrospector interface {
 }
 
 // New returns a new Server.
-func New(issuerURL string, cache cacheGetter, roleScopes map[string][]string) *Server {
+func New(dexServerAddr string, cache cacheGetter, roleScopes map[string][]string) *Server {
 	return &Server{
-		tokenIntrospector: dex.NewDefaultClient(issuerURL),
+		tokenIntrospector: dex.NewDefaultClient(dexServerAddr),
 
 		cache: cache,
 


### PR DESCRIPTION
This simplifies the overall configuration. Also this allows RBAC Server to directly hit Dex, instead of routing via the ingress controller.